### PR TITLE
replace yaml load with safe_load and use the ini read if cli options not used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ dist: xenial
 
 matrix:
     include:
-      - python: 3.5
-        env: TOX_ENV=py35
       - python: 3.6
         env: TOX_ENV=py36
       - python: 3.7

--- a/pytest_securestore.py
+++ b/pytest_securestore.py
@@ -5,7 +5,7 @@ from os import getenv
 
 import pytest
 from pyAesCrypt import decryptStream as decrypt
-from yaml import load as load_yaml
+from yaml import safe_load as load_yaml
 
 
 __all__ = ["store"]
@@ -25,7 +25,7 @@ def pytest_addoption(parser):
         "--secure-store-filename",
         action="store",
         dest="secure_store_filename",
-        default=getenv("SECURE_STORE_FILE", None),
+        default=getenv("SECURE_STORE_FILENAME", None),
         help="Set the secure storage path and filename."
     )
 
@@ -37,7 +37,7 @@ def pytest_addoption(parser):
     parser.addini(
         name="secure_store_filename",
         help="Set the secure storage path and filename.",
-        default=getenv("SECURE_STORE_FILE", None)
+        default=getenv("SECURE_STORE_FILENAME", None)
     )
 
 
@@ -45,7 +45,11 @@ def pytest_addoption(parser):
 def store(request):
     """Decrypt a YAML file and return a value dictionary."""
     password = request.config.option.secure_store_password
+    if not password:
+        password = request.config.getini('secure_store_filename')
     file = request.config.option.secure_store_filename
+    if not file:
+        file = request.config.getini('secure_store_password')
     buffer_size = 64 * 1024  # 64K decryption buffer
 
     # Read in the encrypted, binary file

--- a/pytest_securestore.py
+++ b/pytest_securestore.py
@@ -44,12 +44,12 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="module")
 def store(request):
     """Decrypt a YAML file and return a value dictionary."""
-    password = request.config.option.secure_store_password
-    if not password:
-        password = request.config.getini('secure_store_filename')
     file = request.config.option.secure_store_filename
     if not file:
-        file = request.config.getini('secure_store_password')
+        file = request.config.getini('secure_store_filename')
+    password = request.config.option.secure_store_password
+    if not password:
+        password = request.config.getini('secure_store_password')
     buffer_size = 64 * 1024  # 64K decryption buffer
 
     # Read in the encrypted, binary file

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-securestore',
-    version='0.1.2',
+    version='0.1.3',
     author='Greg Fitch',
     author_email='greg@openstax.org',
     maintainer='Greg Fitch',

--- a/tests/test_securestore.py
+++ b/tests/test_securestore.py
@@ -2,17 +2,17 @@
 
 from io import BytesIO
 from pyAesCrypt import encryptStream
-from yaml import load as load_yaml
+from yaml import safe_load as load_yaml
 
 BUFFER_SIZE = 64 * 1024  # suggested 64K for the encryption buffer
 PLUGIN_NAME = "securestore"
 GENERIC_PASSWORD = "BAD_password!"
-YML_FILE = """---
+YML_FILE = f"""---
 # a comment
 general_user:
-    username: {username}
-    password: {password}
-...""".format(username=PLUGIN_NAME, password=GENERIC_PASSWORD).encode("utf-8")
+    username: {PLUGIN_NAME}
+    password: {GENERIC_PASSWORD}
+...""".encode("utf-8")
 
 
 def test_secure_store_fixture(testdir, tmpdir):
@@ -27,13 +27,13 @@ def test_secure_store_fixture(testdir, tmpdir):
     testdir.makepyfile(
         "\n" +
         "    def test_seek(store):\n" +
-        "        assert store == {}\n".format(load_yaml(YML_FILE))
+        f"        assert store == {load_yaml(YML_FILE)}\n"
     )
 
     # run pytest with the following CL args
     result = testdir.runpytest(
-        '--secure-store-password={}'.format(GENERIC_PASSWORD),
-        "--secure-store-filename={}".format(file),
+        f'--secure-store-password={GENERIC_PASSWORD}',
+        f"--secure-store-filename={file}",
         "-s",
         "-v"
     )
@@ -66,13 +66,13 @@ def test_help_message(testdir):
 
 def test_secure_storage_setting(testdir):
     """Test the INI configuration loads."""
-    testdir.makeini("""
+    testdir.makeini(f"""
         [pytest]
-        secure_store_filename = {file}
-        secure_store_password = {password}
-    """.format(file=PLUGIN_NAME, password=GENERIC_PASSWORD))
+        secure_store_filename = {PLUGIN_NAME}
+        secure_store_password = {GENERIC_PASSWORD}
+    """)
 
-    testdir.makepyfile("""
+    testdir.makepyfile(f"""
         import pytest
 
         @pytest.fixture
@@ -81,8 +81,8 @@ def test_secure_storage_setting(testdir):
                     request.config.getini('secure_store_password')]
 
         def test_secure_storage_ini_settings(store):
-            assert store == ['{file}', '{password}']
-    """.format(file=PLUGIN_NAME, password=GENERIC_PASSWORD))
+            assert store == ['{PLUGIN_NAME}', '{GENERIC_PASSWORD}']
+    """)
 
     result = testdir.runpytest('-v')
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py35,py36,py37,flake8
+envlist = py36,py37,flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
replace `load` as per https://msg.pyyaml.org/load
include INI reads for store filename and password if command line arguments not included